### PR TITLE
Refactoring for using any git host as configuration source

### DIFF
--- a/cmd/sessionender/socket_test.go
+++ b/cmd/sessionender/socket_test.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"testing"
 	"net"
-	"path/filepath"
 	"os"
+	"path/filepath"
+	"testing"
 )
 
 func TestSetupkeepalive(t *testing.T) {
@@ -14,7 +14,7 @@ func TestSetupkeepalive(t *testing.T) {
 	if err := os.WriteFile(socketpath, []byte{}, 0500); err != nil {
 		t.Fatalf("can't write file: %v", err)
 	}
-	
+
 	c, err := setupkeepalive(dir)
 	if err != nil {
 		t.Fatalf("can't make a listener: %v", err)
@@ -25,7 +25,7 @@ func TestSetupkeepalive(t *testing.T) {
 		t.Fatalf("can't stat the socket? %v", err)
 	}
 
-	if got, want := fi.Mode(), os.FileMode(os.ModeSocket | 0666); got != want {
+	if got, want := fi.Mode(), os.FileMode(os.ModeSocket|0666); got != want {
 		t.Errorf("socket has wrong mode got %v, want %v", got, want)
 	}
 
@@ -39,8 +39,7 @@ func TestSetupkeepalive(t *testing.T) {
 	}
 
 	// A rea test would worry about timeouts and such.
-	if got, want := <-c, 1;  got != want {
+	if got, want := <-c, 1; got != want {
 		t.Fatalf("channel wasn't notified")
 	}
 }
-

--- a/config/credential.go
+++ b/config/credential.go
@@ -1,3 +1,4 @@
+//go:build !darwin
 // +build !darwin
 
 package config

--- a/config/namespace_test.go
+++ b/config/namespace_test.go
@@ -5,10 +5,10 @@ import (
 )
 
 func TestLocalNameSpace(t *testing.T) {
-	for _, tv := range []struct{
+	for _, tv := range []struct {
 		input string
-		want string
-	} {
+		want  string
+	}{
 		{
 			"root",
 			"/tmp/ns.root.:0",

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -29,6 +29,7 @@ func addNodeMetadatav2(client *http.Client, nm NodeMetadata) {
 		"githost",
 	}); err != nil {
 		nm["githost"] = "https://git.liqui.org/rjkroege/scripts.git"
+		log.Println("set githost to %q", nm["githost"])
 	}
 }
 
@@ -38,7 +39,7 @@ func addNodeMetadataImpl(client *http.Client, nm NodeMetadata, keys []string) er
 		if err != nil {
 			return  fmt.Errorf("can't get %s %v", k, err)
 		}
-		log.Println(k, "->", v)
+		log.Println(k, "->", string(v))
 		nm[k] = string(v)
 	}
 	return nil
@@ -84,7 +85,7 @@ func readNodeMetadata(entry string, client *http.Client) ([]byte, error) {
 	req, err := http.NewRequest("GET", path, nil)
 	req.Header.Add("Metadata-Flavor", "Google")
 	resp, err := client.Do(req)
-	if err != nil {
+	if err != nil || resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("can't fetch metadata %v: %v", path, err)
 	}
 

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -22,7 +22,6 @@ func GetNodeMetadata(client *http.Client) (NodeMetadata, error) {
 	return nm, nil
 }
 
-
 func addNodeMetadatav2(client *http.Client, nm NodeMetadata) {
 	// TODO(rjk): Populate this with the new path.
 	if err := addNodeMetadataImpl(client, nm, []string{
@@ -37,7 +36,7 @@ func addNodeMetadataImpl(client *http.Client, nm NodeMetadata, keys []string) er
 	for _, k := range keys {
 		v, err := readNodeMetadata(k, client)
 		if err != nil {
-			return  fmt.Errorf("can't get %s %v", k, err)
+			return fmt.Errorf("can't get %s %v", k, err)
 		}
 		log.Println(k, "->", string(v))
 		nm[k] = string(v)
@@ -57,7 +56,7 @@ func addNodeMetadatav1(client *http.Client) (NodeMetadata, error) {
 		"rcloneconfig",
 		"instancetoken",
 	}); err != nil {
-		return nil, err	
+		return nil, err
 	}
 	return nm, nil
 }
@@ -68,7 +67,7 @@ func NewNodeDirectMetadataClient() *http.Client {
 	tr := &http.Transport{
 		ResponseHeaderTimeout: 500 * time.Millisecond,
 	}
-	return  &http.Client{Transport: tr}
+	return &http.Client{Transport: tr}
 }
 
 func NewNodeProxiedMetadataClient(sshtrans http.RoundTripper) *http.Client {

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -1,9 +1,7 @@
 package config
 
-// Serializable parameters for transmission to the node.
 
 import (
-	// TODO(rjk): bunch of stuffs
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -11,6 +9,7 @@ import (
 	"time"
 )
 
+// NodeMetadata is serializable parameters for transmission to the node.
 type NodeMetadata struct {
 	Username      string `json:"username"`
 	GitCredential string `json:"gitcredential"`
@@ -38,7 +37,6 @@ func unifiedNodeMetadata() (*NodeMetadata, error) {
 // legacyNodeMetadata populates a NodeMetadata from the
 // discrete metadata entries on a node.
 func legacyNodeMetadata() (*NodeMetadata, error) {
-
 	username, err := readStringFromMetadata("username")
 	if err != nil {
 		return nil, fmt.Errorf("can't get username %v", err)
@@ -55,11 +53,13 @@ func legacyNodeMetadata() (*NodeMetadata, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can't get sshkey %v", err)
 	}
+	log.Println("sshkey", sshkey)
 
 	rcloneconfig, err := readStringFromMetadata("rcloneconfig")
 	if err != nil {
 		return nil, fmt.Errorf("can't get rcloneconfig %v", err)
 	}
+	log.Println("rcloneconfig", rcloneconfig)
 
 	return &NodeMetadata{
 		Username:      username,

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -14,6 +14,7 @@ type NodeMetadata struct {
 	GitCredential string `json:"gitcredential"`
 	SshKey        string `json:"sshkey"`
 	RcloneConfig  string `json:"rcloneconfig"`
+	InstanceToken  string `json:"instancetoken"`
 }
 
 func GetNodeMetadata(client *http.Client) (*NodeMetadata, error) {
@@ -60,11 +61,18 @@ func legacyNodeMetadata(client *http.Client) (*NodeMetadata, error) {
 	}
 	log.Println("rcloneconfig", string(rcloneconfig))
 
+	instancetoken, err := readNodeMetadata("instancetoken", client)
+	if err != nil {
+		return nil, fmt.Errorf("can't get rcloneconfig %v", err)
+	}
+	log.Println("instancetoken", string(instancetoken))
+
 	return &NodeMetadata{
 		Username:      string(username),
 		GitCredential: string(gitcred),
 		SshKey:        string(sshkey),
 		RcloneConfig:  string(rcloneconfig),
+		InstanceToken:  string(instancetoken),
 	}, nil
 
 }

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -1,0 +1,107 @@
+package config
+
+// Serializable parameters for transmission to the node.
+
+import (
+	// TODO(rjk): bunch of stuffs
+	"fmt"
+	"log"
+	"net/http"
+	"io/ioutil"
+	"time"
+)
+
+
+type NodeMetadata struct {
+	Username string	    `json:"username"`
+	GitCredential string `json:"gitcredential"`
+	SshKey string `json:"sshkey"`
+	RcloneConfig string `json:"rcloneconfig"`
+}
+
+
+func GetNodeMetadata() (*NodeMetadata, error) {
+	nm, err := unifiedNodeMetadata()
+	if err == nil {
+		return nm, nil
+	}
+
+	nm, err = legacyNodeMetadata()
+	if err != nil {
+		return nil, err
+	}
+	return nm, nil
+}
+
+func unifiedNodeMetadata() (*NodeMetadata, error) {
+	return nil, fmt.Errorf("notimplemented")
+}
+
+// legacyNodeMetadata populates a NodeMetadata from the
+// discrete metadata entries on a node.
+func legacyNodeMetadata() (*NodeMetadata, error) {
+
+	username, err := readStringFromMetadata("username")
+	if err != nil {
+		return nil, fmt.Errorf("can't get username %v", err)
+	}
+	log.Println("username", username)
+
+	gitcred, err := readStringFromMetadata("gitcredential")
+	if err != nil {
+		return nil, fmt.Errorf("can't get getcredential %v", err)
+	}
+	log.Println("gitcred", gitcred)
+
+	sshkey, err := readStringFromMetadata("sshkey")
+	if err != nil {
+		return nil, fmt.Errorf("can't get sshkey %v", err)
+	}
+
+	rcloneconfig, err := readStringFromMetadata("rcloneconfig")
+	if err != nil {
+		return nil,  fmt.Errorf("can't get rcloneconfig %v", err)
+	}
+
+	return &NodeMetadata{
+		Username: username,
+		GitCredential: gitcred,
+		SshKey: sshkey,
+		RcloneConfig: rcloneconfig,
+	}, nil
+
+}
+
+// TODO(rjk): Need to also write some kind of function to set the metadata.
+func readStringFromMetadata(entry string) (string, error) {
+	path := metabase + entry
+
+// Adjust this for the timeout.
+// This should be faster now.
+tr := &http.Transport{
+	ResponseHeaderTimeout: 500 * time.Millisecond,
+}
+	client := &http.Client{Transport: tr}
+	req, err := http.NewRequest("GET", path, nil)
+	req.Header.Add("Metadata-Flavor", "Google")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("can't fetch metadata %v: %v", path, err)
+	}
+
+	buffy, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("can't read metadata body %v: %v", path, err)
+	}
+	return string(buffy), nil
+}
+
+const metabase = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/"
+
+
+func RunningInGcp() bool {
+		if _, err := readStringFromMetadata("username"); err == nil {
+			return true
+		}
+	return false
+}

--- a/config/nodeparms.go
+++ b/config/nodeparms.go
@@ -5,20 +5,18 @@ package config
 import (
 	// TODO(rjk): bunch of stuffs
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
-	"io/ioutil"
 	"time"
 )
 
-
 type NodeMetadata struct {
-	Username string	    `json:"username"`
+	Username      string `json:"username"`
 	GitCredential string `json:"gitcredential"`
-	SshKey string `json:"sshkey"`
-	RcloneConfig string `json:"rcloneconfig"`
+	SshKey        string `json:"sshkey"`
+	RcloneConfig  string `json:"rcloneconfig"`
 }
-
 
 func GetNodeMetadata() (*NodeMetadata, error) {
 	nm, err := unifiedNodeMetadata()
@@ -60,14 +58,14 @@ func legacyNodeMetadata() (*NodeMetadata, error) {
 
 	rcloneconfig, err := readStringFromMetadata("rcloneconfig")
 	if err != nil {
-		return nil,  fmt.Errorf("can't get rcloneconfig %v", err)
+		return nil, fmt.Errorf("can't get rcloneconfig %v", err)
 	}
 
 	return &NodeMetadata{
-		Username: username,
+		Username:      username,
 		GitCredential: gitcred,
-		SshKey: sshkey,
-		RcloneConfig: rcloneconfig,
+		SshKey:        sshkey,
+		RcloneConfig:  rcloneconfig,
 	}, nil
 
 }
@@ -76,11 +74,11 @@ func legacyNodeMetadata() (*NodeMetadata, error) {
 func readStringFromMetadata(entry string) (string, error) {
 	path := metabase + entry
 
-// Adjust this for the timeout.
-// This should be faster now.
-tr := &http.Transport{
-	ResponseHeaderTimeout: 500 * time.Millisecond,
-}
+	// Adjust this for the timeout.
+	// This should be faster now.
+	tr := &http.Transport{
+		ResponseHeaderTimeout: 500 * time.Millisecond,
+	}
 	client := &http.Client{Transport: tr}
 	req, err := http.NewRequest("GET", path, nil)
 	req.Header.Add("Metadata-Flavor", "Google")
@@ -98,10 +96,9 @@ tr := &http.Transport{
 
 const metabase = "http://metadata.google.internal/computeMetadata/v1/instance/attributes/"
 
-
 func RunningInGcp() bool {
-		if _, err := readStringFromMetadata("username"); err == nil {
-			return true
-		}
+	if _, err := readStringFromMetadata("username"); err == nil {
+		return true
+	}
 	return false
 }

--- a/config/settings.go
+++ b/config/settings.go
@@ -8,12 +8,12 @@ import (
 )
 
 type InstanceConfig struct {
-	Family       string `json:"family"`
-	Hardware     string `json:"hardware"`
-	DiskSize     string `json:"disksize,omitempty"`
-	Zone         string `json:"zone,omitempty"`
-	Description  string `json:"description,omitempty"`
-	UserDataFile string `json:"userdatafile,omitempty"`
+	Family        string `json:"family"`
+	Hardware      string `json:"hardware"`
+	DiskSize      string `json:"disksize,omitempty"`
+	Zone          string `json:"zone,omitempty"`
+	Description   string `json:"description,omitempty"`
+	UserDataFile  string `json:"userdatafile,omitempty"`
 	PostSshConfig string `json:"postsshconfig,omitempty"`
 }
 

--- a/gcp/list_instances.go
+++ b/gcp/list_instances.go
@@ -9,7 +9,6 @@ import (
 	compute "google.golang.org/api/compute/v1"
 )
 
-
 func getInstances(settings *config.Settings) (*compute.InstanceList, error) {
 	_, client, err := NewAuthenticatedClient([]string{
 		compute.ComputeScope,
@@ -28,9 +27,8 @@ func getInstances(settings *config.Settings) (*compute.InstanceList, error) {
 	zone := settings.DefaultZone
 
 	// List the current instances.
-	return  service.Instances.List(projectId, zone).Do()
+	return service.Instances.List(projectId, zone).Do()
 }
-
 
 func List(settings *config.Settings) error {
 	res, err := getInstances(settings)
@@ -57,7 +55,7 @@ func List(settings *config.Settings) error {
 }
 
 func GetNodeIp(settings *config.Settings, wantednode string) (string, error) {
-	res, err  := getInstances(settings)
+	res, err := getInstances(settings)
 	if err != nil {
 		return "", fmt.Errorf("getting instance list failed: %v", err)
 	}

--- a/gcp/new_node.go
+++ b/gcp/new_node.go
@@ -21,10 +21,10 @@ func parseDiskSize(szs string) (int64, error) {
 // NodeInfo holds all the state necessary for subsequent utilities to be
 // able to connect to the node.
 type NodeInfo struct {
-	Name  string
+	Name       string
 	ConfigName string
-	Addr  string
-	Token string
+	Addr       string
+	Token      string
 }
 
 // Ssh returns the address for an SSH connection to the node.
@@ -43,12 +43,12 @@ func MakeNode(settings *config.Settings, configName, instanceName string) (*Node
 	}
 
 	familyName := settings.InstanceTypes[configName].Family
-log.Println("familyName", familyName)
+	log.Println("familyName", familyName)
 	latestimage, err := findNewestStableImage(ctx, client, familyName)
 	if err != nil {
 		return nil, fmt.Errorf("can't find desired stable image", err)
 	}
-log.Println("latestimage", latestimage)
+	log.Println("latestimage", latestimage)
 
 	// TODO(rjk): reuse the service.
 	service, err := compute.New(client)
@@ -80,7 +80,6 @@ log.Println("latestimage", latestimage)
 		Name:        instanceName,
 		Description: settings.Description(configName, instanceName),
 		MachineType: prefix + "/zones/" + zone + "/machineTypes/" + machinetype,
-
 
 		Disks: []*compute.AttachedDisk{
 			{
@@ -154,10 +153,10 @@ log.Println("latestimage", latestimage)
 			if err == nil && inst.Status == "RUNNING" {
 				// Yes, it's running and has an IP.
 				return &NodeInfo{
-					Name:  inst.Name,
+					Name:       inst.Name,
 					ConfigName: configName,
-					Addr:  ip,
-					Token: metadata["instancetoken"],
+					Addr:       ip,
+					Token:      metadata["instancetoken"],
 				}, nil
 			}
 			// Not in the right state yet. Try again.

--- a/gcp/new_node.go
+++ b/gcp/new_node.go
@@ -74,10 +74,13 @@ log.Println("latestimage", latestimage)
 		return nil, fmt.Errorf("can't make metadata: %v", err)
 	}
 
+	diskName := fmt.Sprintf("%s-root", instanceName)
+
 	instance := &compute.Instance{
 		Name:        instanceName,
 		Description: settings.Description(configName, instanceName),
 		MachineType: prefix + "/zones/" + zone + "/machineTypes/" + machinetype,
+
 
 		Disks: []*compute.AttachedDisk{
 			{
@@ -86,7 +89,7 @@ log.Println("latestimage", latestimage)
 				Type:       "PERSISTENT",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					// TODO(rjk): compute something better
-					DiskName:    "ween-root",
+					DiskName:    diskName,
 					DiskSizeGb:  disksize,
 					SourceImage: imageURL,
 				},

--- a/gcp/ssh_driven_config.go
+++ b/gcp/ssh_driven_config.go
@@ -34,7 +34,6 @@ func ConfigureViaSsh(settings *config.Settings, ni *NodeInfo, client *ssh.Client
 	// that an adversary could man-in-the-middle me is if a router between me and
 	// Google has been misconfigured and can forward traffic to an arbitrary
 	// third party. I must validate some kind of shared secret.
-
 	pnm, err := config.GetNodeMetadata(
 		config.NewNodeProxiedMetadataClient(NewSshProxiedTransport(client)))
 	if err != nil {
@@ -64,28 +63,6 @@ func ConfigureViaSsh(settings *config.Settings, ni *NodeInfo, client *ssh.Client
 	return nil
 }
 
-// TODO(rjk): Must refactor this to address the fact that I may want to do this over a
-// different transport/client combo.
-// So want to plumb the transport into the config top level interface.
-// func readStingFromMetadata(entry string, sshclient *ssh.Client) (string, error) {
-// 	path := metabase + entry
-// 	client := &http.Client{
-// 		Transport: NewSshProxiedTransport(sshclient),
-// 	}
-// 	req, err := http.NewRequest("GET", path, nil)
-// 	req.Header.Add("Metadata-Flavor", "Google")
-// 	resp, err := client.Do(req)
-// 	if err != nil {
-// 		return "", fmt.Errorf("can't fetch metadata %v: %v", path, err)
-// 	}
-// 
-// 	buffy, err := ioutil.ReadAll(resp.Body)
-// 	if err != nil {
-// 		return "", fmt.Errorf("can't read metadata body %v: %v", path, err)
-// 	}
-// 	return string(buffy), nil
-// }
-// 
 func NewSshProxiedTransport(client *ssh.Client) http.RoundTripper {
 	dolly := http.DefaultTransport.(*http.Transport).Clone()
 

--- a/gcp/ssh_driven_config.go
+++ b/gcp/ssh_driven_config.go
@@ -40,7 +40,7 @@ func ConfigureViaSsh(settings *config.Settings, ni *NodeInfo, client *ssh.Client
 		return fmt.Errorf("can't read proxied node metadata: %v", err)
 	}
 
-	gottoken := pnm.InstanceToken
+	gottoken := pnm["instancetoken"]
 	if gottoken != ni.Token {
 		return fmt.Errorf("Got token %q, want %q. Maybe this is an IP hijack?", gottoken, ni.Token)
 	}

--- a/gcp/ssh_driven_config.go
+++ b/gcp/ssh_driven_config.go
@@ -61,6 +61,9 @@ func ConfigureViaSsh(settings *config.Settings, ni *NodeInfo, client *ssh.Client
 	return nil
 }
 
+// TODO(rjk): Must refactor this to address the fact that I may want to do this over a
+// different transport/client combo.
+// So want to plumb the transport into the config top level interface.
 func readStingFromMetadata(entry string, sshclient *ssh.Client) (string, error) {
 	path := metabase + entry
 	client := &http.Client{

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20201203001011-0b49973bad19
 	google.golang.org/api v0.36.0
+	google.golang.org/grpc v1.33.2 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -286,6 +286,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/who/meldwholists.go
+++ b/who/meldwholists.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TimestampWhoList(wl WhoList) {
-	for k, _ := range wl {
+	for k := range wl {
 		fi, err := os.Stat(k)
 		if err != nil {
 			delete(wl, k)
@@ -17,7 +17,7 @@ func TimestampWhoList(wl WhoList) {
 }
 
 func MergeWhoList(oldwl, newwl WhoList) {
-	for k, _ := range newwl {
+	for k := range newwl {
 		if _, ok := oldwl[k]; !ok {
 			oldwl[k] = newwl[k]
 		}

--- a/who/meldwholists_test.go
+++ b/who/meldwholists_test.go
@@ -3,8 +3,8 @@ package who
 import (
 	"io/ioutil"
 	"os"
-	"testing"
 	"path/filepath"
+	"testing"
 	"time"
 )
 
@@ -30,11 +30,10 @@ func TestTimestampWhoList(t *testing.T) {
 	}
 	// Make a single file in the temp directory.
 	if _, err = os.Create(p2); err != nil {
-		t.Fatal("couldn't make a file",p2, "because", err)
+		t.Fatal("couldn't make a file", p2, "because", err)
 	}
 
 	now := time.Now()
-	
 
 	// Make an inputwholist
 	inputwholist := WhoList{
@@ -47,10 +46,10 @@ func TestTimestampWhoList(t *testing.T) {
 	if _, ok := inputwholist[p0]; ok {
 		t.Error("inputwholist should have p0 removed", inputwholist)
 	}
-	if ti, ok := inputwholist[p1]; !ok || now.Sub(ti) > time.Duration(10 * time.Second) {
-		t.Error("inputwholist should have p1 updated", inputwholist)		
+	if ti, ok := inputwholist[p1]; !ok || now.Sub(ti) > time.Duration(10*time.Second) {
+		t.Error("inputwholist should have p1 updated", inputwholist)
 	}
-	if _, ok := inputwholist[p2]; ok  {
-		t.Error("inputwholist should have not have added p2", inputwholist)	
+	if _, ok := inputwholist[p2]; ok {
+		t.Error("inputwholist should have not have added p2", inputwholist)
 	}
 }


### PR DESCRIPTION
Historically gocloud has assumed that system configuration for a new
node is kept in a git repository. I hard-coded the address of this
repository. That's not very flexible. This PR begins a series of
changes to relax this assumption.
